### PR TITLE
Use a list of possible vendor paths in bin/docbuilder.

### DIFF
--- a/bin/docbuilder
+++ b/bin/docbuilder
@@ -1,7 +1,23 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__.'/../vendor/autoload.php';
+/* Search for possible vendor paths to support direct and composer installs. */
+$paths = [
+    __DIR__ . '/../vendor/autoload.php',
+    __DIR__ . '/../../../autoload.php',
+];
+
+foreach ($paths as $path) {
+    if (file_exists($path)) {
+        require_once $path;
+        break;
+    }
+}
+
+/* Toss out a warning if this is probably going to fail. */
+if (!class_exists('\Vectorface\DocBuilder\BuilderApp', true)) {
+    error_log("Warning: autoload failed. Please ensure you have run composer intall.");
+}
 
 $app = new \Vectorface\DocBuilder\BuilderApp();
 $app->run();


### PR DESCRIPTION
## Summary

This change improves compatibility when docbuilder is installed with composer.
## Details

In my environment, the `bin/docbuilder` executable works properly when used directly from its project directory. If installed via composer, running `vendor/bin/docbuilder` produces a require error because the vendor autoloader path is not in the expected location.

By searching both possible locations for the autoloader, both the direct checkout and composer-installed versions of docbuilder should work.
