### PR TITLE
Fix printing of intermediate HTML. 

### DIFF
--- a/src/Builder.php
+++ b/src/Builder.php
@@ -23,6 +23,7 @@ class Builder
         $this->markdown = @file_get_contents($markdown);
         $this->css = @file_get_contents($css);
         $this->filename = $markdown;
+        $this->printhtml = $printhtml;
         $this->output = $output;
 
         if ($this->markdown === false) {
@@ -49,14 +50,16 @@ class Builder
         $html .= $converter->convertToHtml($this->markdown);
         $html .= "</body></html>";
 
-        $filename = getcwd().'/'.preg_replace('/.[^.]*$/', '', $this->output);
-
-        if ($this->puthtml) {
-            file_put_contents($filename.".html", $html);
-        }
-
         $mpdf->WriteHTML($html);
         $mpdf->Output($this->output, 'F');
+
+        if ($this->printhtml) {
+            if ($this->printhtml === '-') {
+                echo $html;
+            } else {
+                file_put_contents($this->printhtml, $html);
+            }
+        }
 
         exit(0);
     }

--- a/src/BuilderApp.php
+++ b/src/BuilderApp.php
@@ -20,7 +20,7 @@ class BuilderApp
     {
         $getopt = new Getopt(array(
             new Option('c', 'css', Getopt::REQUIRED_ARGUMENT),
-            new Option('p', 'printhtml'),
+            new Option('p', 'printhtml', Getopt::OPTIONAL_ARGUMENT),
             new Option('h', 'help'),
             new Option('v', 'version')
         ));
@@ -36,12 +36,6 @@ class BuilderApp
 
             if ($getopt['help']) {
                 $this->showUsage(0);
-            }
-
-            if ($getopt['printhtml']) {
-                $printhtml = true;
-            } else {
-                $printhtml = false;
             }
 
             if ($getopt['css']) {
@@ -64,6 +58,14 @@ class BuilderApp
                 $output = getcwd().'/'.preg_replace('/.[^.]*$/', '', $markdown).".pdf";
             }
 
+            if ($getopt['printhtml'] === 1) {
+                $printhtml = dirname($output) . '/' . basename($output, ".pdf") . ".html";
+            } elseif (!empty($getopt['printhtml']) && is_string($getopt['printhtml'])) {
+                $printhtml = $getopt['printhtml'];
+            } else {
+                $printhtml = false;
+            }
+
             /* Run the builder tool */
             $builder = new Builder($markdown, $css, $printhtml, $output);
             $builder->buildPDF();
@@ -83,7 +85,7 @@ class BuilderApp
         echo "Converts Markdown files to pdf.\n\n";
         echo "Options:\n";
         echo "  -c, --css=FILE   provide css file for styling (overrides default styling)\n";
-        echo "  -p, --printhtml  output intermediate html file\n";
+        echo "  -p, --printhtml  output intermediate html file (accepts optional filename argument)\n";
         echo "  -h, --help       display this help and exit\n";
         echo "  -v, --version    output version number and exit\n";
 


### PR DESCRIPTION
This change also allows printing to a specific filename or stdout.

Examples:

``` bash
# Works like it did before: outputs file.pdf
$ bin/docbuilder file.md

# Writes both file.html and file.pdf
$ bin/docbuilder -p -- file.md

# Writes to a custom HTML filename.
$ bin/docbuilder -p custom.htm file.md

# Outputs to stdout (echo)
$ bin/docbuilder -p - file.md
```
